### PR TITLE
Introduction of a compatibility "ntex" framework and change of optional versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Works with `diesel` and `Postgres`.
 ## Crate features
 
 - `rocket` Derives `FromForm` on the generated filter struct ([See this example](#with-rocket))
-- `actix` Derives `Deserialize` on the generated filter struct ([See this example](#with-actix))
+- `actix`/`ntex` Derives `Deserialize` on the generated filter struct ([See this example](#with-actix-or-ntex))
 - `serialize` with `pagination` Adds the `PaginatedPayload` trait that can directly be sent to your client
 
 ## Changes in 2.0
@@ -62,9 +62,9 @@ Project::filter(&filters)
 
 With the `rocket` feature, the generated struct can be obtained from the request query parameters (dot notation `?filters.name=xxx`)
 
-### With Actix
+### With Actix or Ntex
 
-With the `actix` feature, the generated struct can be obtained from the request query parameters
+With the `actix` or `ntex` feature, the generated struct can be obtained from the request query parameters
 
 N.B: unlike the `rocket` integration, the query parameters must be sent unscopped. e.g `?field=xxx&other=1`
 

--- a/diesel_filter/Cargo.lock
+++ b/diesel_filter/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "diesel_filter_query",
  "serde",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter_query"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "darling 0.21.1",
  "proc-macro2",

--- a/diesel_filter/Cargo.toml
+++ b/diesel_filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_filter"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Terry Raimondo <terry.raimondo@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -15,9 +15,10 @@ serde = ["dep:serde"]
 rocket = ["diesel_filter_query/rocket"]
 actix = ["diesel_filter_query/actix", "dep:serde_with"]
 axum = ["diesel_filter_query/axum", "dep:serde_with"]
+ntex = ["diesel_filter_query/ntex", "dep:serde_with"]
 utoipa = ["diesel_filter_query/utoipa"]
 
 [dependencies]
-diesel_filter_query = { path = "../diesel_filter_query", version = "2.0.0" }
+diesel_filter_query = { path = "../diesel_filter_query", version = "2.1.0" }
 serde = { version = "1.0", optional = true }
 serde_with = { version = "3.14.0", optional = true }

--- a/diesel_filter/src/lib.rs
+++ b/diesel_filter/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "actix", feature = "axum"))]
+#[cfg(any(feature = "actix", feature = "axum", feature = "ntex"))]
 pub use serde_with;
 
 pub use diesel_filter_query::*;

--- a/diesel_filter_query/Cargo.lock
+++ b/diesel_filter_query/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter_query"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/diesel_filter_query/Cargo.toml
+++ b/diesel_filter_query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_filter_query"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Terry Raimondo <terry.raimondo@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -14,6 +14,7 @@ readme = "../README.md"
 rocket = []
 actix = []
 axum = []
+ntex = []
 utoipa = []
 
 [dependencies]

--- a/diesel_filter_query/src/lib.rs
+++ b/diesel_filter_query/src/lib.rs
@@ -146,7 +146,7 @@ pub fn diesel_filter_derive(input: TokenStream) -> TokenStream {
             #[cfg(feature = "rocket")]
             field_attributes.push(quote! { #[field(default = Option::None)] });
 
-            #[cfg(any(feature = "actix", feature = "axum"))]
+            #[cfg(any(feature = "actix", feature = "axum", feature = "ntex"))]
             {
                 let serde_as_path = format!(
                     "Option<::diesel_filter::serde_with::StringWithSeparator::<::diesel_filter::serde_with::formats::CommaSeparator, {}>>",
@@ -228,7 +228,7 @@ pub fn diesel_filter_derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    #[cfg(any(feature = "actix", feature = "axum"))]
+    #[cfg(any(feature = "actix", feature = "axum", feature = "ntex"))]
     let filters_struct = quote! {
         #[::diesel_filter::serde_with::serde_as(crate = "::diesel_filter::serde_with")]
         #[derive(serde::Deserialize, #( #extra_derive, )*)]
@@ -237,7 +237,7 @@ pub fn diesel_filter_derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    #[cfg(not(any(feature = "rocket", feature = "actix", feature = "axum")))]
+    #[cfg(not(any(feature = "rocket", feature = "actix", feature = "axum", feature = "ntex")))]
     let filters_struct = quote! {
         #[derive(#( #extra_derive, )*)]
         pub struct #filter_struct_ident {

--- a/diesel_pagination/Cargo.lock
+++ b/diesel_pagination/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_pagination"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "diesel",
  "diesel-async",

--- a/diesel_pagination/Cargo.toml
+++ b/diesel_pagination/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_pagination"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Terry Raimondo <terry.raimondo@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ serde = ["dep:serde"]
 utoipa = ["dep:utoipa"]
 
 [dependencies]
-diesel = "2.2.12"
-diesel-async = { version = "0.6.1", optional = true }
-serde = { version = "1.0", optional = true }
-utoipa = { version = "5.4.0", optional = true }
+diesel = "2"
+diesel-async = { version = "0", optional = true }
+serde = { version = "1", optional = true }
+utoipa = { version = "5", optional = true }

--- a/diesel_pagination/src/lib.rs
+++ b/diesel_pagination/src/lib.rs
@@ -88,7 +88,7 @@ impl<T> PaginatedQuery<T> {
     pub fn load_and_count<'a, U, Conn>(self, conn: &mut Conn) -> QueryResult<Paginated<U>>
     where
         Self: diesel::query_dsl::methods::LoadQuery<'a, Conn, (U, i64)>,
-        Conn: diesel::connection::Connection,
+        Conn: Connection,
     {
         let Self { page, per_page, .. } = self;
         let results = self.load::<(U, i64)>(conn)?;

--- a/examples/diesel-async/Cargo.lock
+++ b/examples/diesel-async/Cargo.lock
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "diesel_filter_query",
  "serde",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter_query"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "darling 0.21.1",
  "proc-macro2",

--- a/examples/diesel-sync/Cargo.lock
+++ b/examples/diesel-sync/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "diesel_filter_query",
 ]
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter_query"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "darling 0.21.1",
  "proc-macro2",

--- a/examples/pagination/Cargo.lock
+++ b/examples/pagination/Cargo.lock
@@ -376,14 +376,14 @@ dependencies = [
 
 [[package]]
 name = "diesel_filter"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "diesel_filter_query",
 ]
 
 [[package]]
 name = "diesel_filter_query"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "darling 0.21.1",
  "proc-macro2",

--- a/examples/pagination/Cargo.lock
+++ b/examples/pagination/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "diesel_pagination"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "diesel",
  "diesel-async",


### PR DESCRIPTION
Hey 👋! In this PR, support for the [ntex](https://ntex.rs) framework was introduced and the dependency versions on crate `diesel_pagination` were changed so that they only have the master version, this way, in our development that integrates the crate `diesel_pagination`, the versions of the dependencies do not need to be exactly the same from the crate, giving us the freedom to choose the versions, but the master version must be that one.